### PR TITLE
fix: remove food detail duplicated request

### DIFF
--- a/RecipeApp/src/Projects/App/Sources/Scenes/Food/FoodCoordinator.swift
+++ b/RecipeApp/src/Projects/App/Sources/Scenes/Food/FoodCoordinator.swift
@@ -34,8 +34,8 @@ final class FoodCoordinator<FoodCodable: Codable>: Coordinator {
 }
 
 extension FoodCoordinator: FoodNavigation {
-    func goToFoodDetail(food: Food) {
-        var foodDetailsCoordinator = detailsFactory.make(foodId: food.id,
+    func goToFoodDetail(foodId: String) {
+        var foodDetailsCoordinator = detailsFactory.make(foodId: foodId,
                                                          foodType: foodType,
                                                          navigationController: navigationController)
         children.append(foodDetailsCoordinator)

--- a/RecipeApp/src/Projects/App/Sources/Scenes/Food/Protocols/FoodProtocols.swift
+++ b/RecipeApp/src/Projects/App/Sources/Scenes/Food/Protocols/FoodProtocols.swift
@@ -25,5 +25,5 @@ protocol FoodViewModelDelegateProtocol: AnyObject {
 
 protocol FoodNavigation: AnyObject {
     func goToFoodView()
-    func goToFoodDetail(food: Food)
+    func goToFoodDetail(foodId: String)
 }

--- a/RecipeApp/src/Projects/App/Sources/Scenes/Food/View/FoodViewController.swift
+++ b/RecipeApp/src/Projects/App/Sources/Scenes/Food/View/FoodViewController.swift
@@ -63,7 +63,6 @@ final class FoodViewController: UICollectionViewController {
         if indexPath.section == 1 {
             let recipe = recipes[indexPath.row]
             viewModel?.didTapFoodCell(id: recipe.id)
-            changeToLoadingState()
         }
     }
 

--- a/RecipeApp/src/Projects/App/Sources/Scenes/Food/ViewModel/FoodViewModel.swift
+++ b/RecipeApp/src/Projects/App/Sources/Scenes/Food/ViewModel/FoodViewModel.swift
@@ -28,7 +28,7 @@ final class FoodViewModel: FoodViewModelProtocol {
             switch response {
             case .success(let foods):
                 if let randomFood = foods.foods.first {
-                    self?.foodNavigation?.goToFoodDetail(food: randomFood)
+                    self?.foodNavigation?.goToFoodDetail(foodId: randomFood.id)
                 }
             case .failure(let error):
                 self?.delegate?.didFailLoadedFood(title: "Error on load random food.",
@@ -61,16 +61,7 @@ final class FoodViewModel: FoodViewModelProtocol {
     }
 
     func didTapFoodCell(id: String) {
-        service.getFoodById(id: id) { [weak self] result in
-            switch result {
-            case .success(let foods):
-                if let food = foods.foods.first {
-                    self?.foodNavigation?.goToFoodDetail(food: food)
-                }
-            case .failure(let error):
-                self?.delegate?.didFailLoadedFood(title: "Error on load food by id.", error: error.localizedDescription)
-            }
-        }
+        foodNavigation?.goToFoodDetail(foodId: id)
     }
 
     private func handleResponse(response: Result<FoodsProtocol, Error>) {

--- a/RecipeApp/src/Projects/App/Tests/Scenes/Food/FoodCoordinatorTests.swift
+++ b/RecipeApp/src/Projects/App/Tests/Scenes/Food/FoodCoordinatorTests.swift
@@ -24,7 +24,7 @@ class FoodCoordinatorTests: XCTestCase {
         let sut = makeSut()
         let meal = try XCTUnwrap(FoodMocks.shared.mockMeal().first)
         
-        sut.goToFoodDetail(food: meal)
+        sut.goToFoodDetail(foodId: meal.id)
 
         XCTAssertTrue(sut.children.first is CoordinatorDummy)
     }

--- a/RecipeApp/src/Projects/App/Tests/Scenes/Food/ViewModel/FoodViewModelTests.swift
+++ b/RecipeApp/src/Projects/App/Tests/Scenes/Food/ViewModel/FoodViewModelTests.swift
@@ -40,7 +40,7 @@ final class FoodViewModelTests: XCTestCase {
         
         XCTAssertTrue(service.getRandomFoodCalled)
         XCTAssertTrue(navigation.goToFoodDetailCalled)
-        XCTAssertEqual(navigation.food?.id, "52772")
+        XCTAssertEqual(navigation.foodId, "52772")
     }
     
     func test_randomFood_should_call_didFailLoadedFood() {
@@ -98,24 +98,12 @@ final class FoodViewModelTests: XCTestCase {
     }
     
     func test_didTapFoodCell_loaded_food_with_success() {
-        let (sut, _, service, navigation) = makeSut()
+        let (sut, _, _, navigation) = makeSut()
 
         sut.didTapFoodCell(id: "52772")
 
-        XCTAssertTrue(service.getFoodByIdCalled)
         XCTAssertTrue(navigation.goToFoodDetailCalled)
-        XCTAssertEqual(navigation.food?.id, "52772")
-    }
-    
-    func test_didTapFoodCell_loaded_food_with_error() {
-        let (sut, delegate, service, _) = makeSut(isSuccess: false)
-
-        sut.didTapFoodCell(id: "52772")
-        
-        XCTAssertTrue(service.getFoodByIdCalled)
-        XCTAssertTrue(delegate.didFailLoadedFoodCalled)
-        XCTAssertEqual(delegate.errorTitle, "Error on load food by id.")
-        XCTAssertEqual(delegate.errorMessage, "Load Food By Id error.")
+        XCTAssertEqual(navigation.foodId, "52772")
     }
 
     func makeSut(isSuccess: Bool = true) -> (FoodViewModel,
@@ -133,14 +121,14 @@ final class FoodViewModelTests: XCTestCase {
 }
 
 final class FoodNavigationSpy: FoodNavigation {
-    var food: Food?
-    
+    var foodId: String?
+
     func goToFoodView() {}
     
     var goToFoodDetailCalled = false
-    func goToFoodDetail(food: Food) {
+    func goToFoodDetail(foodId: String) {
         goToFoodDetailCalled = true
-        self.food = food
+        self.foodId = foodId
     }
 }
 


### PR DESCRIPTION
### Description
- Remove get food detail request from `FoodViewModel`
- Change to use food id instead of food instance

|![](https://github.com/user-attachments/assets/77c96686-46c4-4242-bb2f-84d9172f9d29)|![](https://github.com/user-attachments/assets/58b3612a-d6db-4bdf-af81-b0cf9a5e1f35)|
|:-:|:-:|
|Duplicate request|Request only on detail|